### PR TITLE
allow passing custom flags to jest

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,7 @@ command! JestInit :call CocAction('runCommand', 'jest.init')
 - `jest.forceExit`: force jest exit on test finish, default `false`.
 - `jest.noStackTrace`: disable stack trace, default `false`.
 - `jest.terminalPosition`: position of terminal, default `right`.
+- `jest.customFlags`: pass additional custom flags to Jest, default `[]`.
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,16 @@
         "jest.configFileName": {
           "type": "string",
           "default": "jest.config.js"
+        },
+        "jest.customFlags": {
+          "type": "array",
+          "description": "Pass additional custom flags to Jest command.",
+          "default": [],
+          "items": {
+            "type": "string",
+            "description": "A flag, without the '--'. For example: 'runInBand' or 'useStderr'.",
+            "default": ""
+          }
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,11 @@ async function resolveConfig(): Promise<string> {
       args.push(`--${name}`)
     }
   }
+  if (config.get('customFlags')) {
+    for (let flag of config.get<String[]>('customFlags')) {
+      args.push(`--${flag}`)
+    }
+  }
   return args.join(' ')
 }
 


### PR DESCRIPTION
Hi, I want to pass arbitrary flags to Jest, with something in `coc-settings.json` like:
```json
{
  "jest.customFlags": ["runInBand", "verbose", "expand"]
}
```
Is this an idea worth pursuing? thanks