### PR TITLE
Bumping version to get #7 out

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-jest",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "jest extension for coc.nvim",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Alternatively, we can republish 1.0.3 to get the code out but I think explicitly bumping the version is better.