### PR TITLE
fix: find jest cofig from document's path

### DIFF
--- a/src/utils/path/jestConfig.ts
+++ b/src/utils/path/jestConfig.ts
@@ -1,4 +1,5 @@
-import { workspace } from 'coc.nvim'
+import { workspace } from "coc.nvim"
+import { fileURLToPath } from "url"
 import { getConfiguration } from "../configs"
 import { findUp } from "./common"
 
@@ -13,11 +14,12 @@ export const makeJestConfigCmd = async () => {
 }
 
 const findJestConfigPath = async () => {
-  const { root } = workspace
+  const document = await workspace.document
+  const documentPath = fileURLToPath(document.uri)
   const config = await getConfiguration()
   const configFileName = config.get<string>("configFileName")
 
-  const configPath = await findUp(configFileName, root)
+  const configPath = await findUp(configFileName, documentPath)
 
   if (configPath === "") {
     return ""


### PR DESCRIPTION
In monorepos, jest config files are not always in the root directory, sometimes there are configurations per workspaces, so this commit fixes that by using the document's path and finding the config up the file tree.