### PR TITLE
fix: handle falsy documents and when document URI's scheme is not a file

### DIFF
--- a/src/utils/path/jestConfig.ts
+++ b/src/utils/path/jestConfig.ts
@@ -1,5 +1,5 @@
-import { workspace } from "coc.nvim"
-import { fileURLToPath } from "url"
+import { Uri, workspace } from "coc.nvim"
+import path from "path"
 import { getConfiguration } from "../configs"
 import { findUp } from "./common"
 
@@ -15,11 +15,16 @@ export const makeJestConfigCmd = async () => {
 
 const findJestConfigPath = async () => {
   const document = await workspace.document
-  const documentPath = fileURLToPath(document.uri)
   const config = await getConfiguration()
   const configFileName = config.get<string>("configFileName")
 
-  const configPath = await findUp(configFileName, documentPath)
+  let cwd = workspace.cwd;
+  if (document) {
+    const uri = Uri.parse(document.uri);
+    cwd = uri.scheme == "file" ? path.dirname(uri.fsPath) : cwd;
+  }
+
+  const configPath = await findUp(configFileName, cwd)
 
   if (configPath === "") {
     return ""


### PR DESCRIPTION
I noticed that some coc plugins, including this one itself, are checking for document's truthiness and also document URI is not always a 'file', so this commit handle those two cases and defaulting to workspace's cwd.

I'm not sure if we want to also consider cases where the document is not a file, I'm not too familiarised with nvim/coc to know if we just want to check for document to exist, maybe if document is defined it always will be a file? maybe this is enough:

```js
  const cwd = document ? fileURLToPath(document.uri) : workspace.cwd;
  const configPath = await findUp(configFileName, cwd)
```

References:
- https://github.com/neoclide/coc-jest/blob/8fdc44753664c36ee3870e93ff5ddc6387ef7e54/src/utils/configs.ts#L68
- https://github.com/khanghoang/coc-jest/blob/d277d0f9481d1b42e6dcd297ee64d79ab769bdae/src/resolveRoot.ts#L8

PS: I'm just being cautious